### PR TITLE
Update dockerfile e upgrade jekyll

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
-    jekyll (4.0.0)
+    jekyll (4.0.1)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,12 @@
 FROM ubuntu:latest
-RUN apt-get update
-RUN apt-get install -y build-essential git ruby-full ruby-bundler zlib1g-dev curl
-RUN gem install bundler -v 1.17.3
+
+RUN apt-get update && \
+    apt-get install -y build-essential git ruby-full ruby-bundler zlib1g-dev curl && \
+    gem install bundler -v 1.17.3
+
 VOLUME ["/opt"]
 WORKDIR /opt
 COPY start_dev.sh /bin/start_dev.sh
 RUN chmod +x /bin/start_dev.sh
+
 CMD [ "start_dev.sh" ]


### PR DESCRIPTION
- small fix nel Dockerfile
- upgrade di Jekyll da 4.0.0 a 4.0.1 per rimuovere console warning con Ruby 2.7 (https://github.com/jekyll/jekyll/releases/tag/v4.0.1)

A disposizione per eventuali osservazioni.