### PR TITLE
Add statistics page and script

### DIFF
--- a/_data/i18n/navigation.yml
+++ b/_data/i18n/navigation.yml
@@ -11,6 +11,7 @@ languages:
         - PARTNER: "partners/"
         - PRESS: "press/"
         - DOMANDE FREQUENTI: "faq/"
+        - STATISTICHE: "stat/"
         - USA I NOSTRI DATI: "opendata/"
       PARTECIPA:
         - COME PARTECIPARE: "contribuisci/"
@@ -28,6 +29,7 @@ languages:
         - ABOUT: "en/about/"
         - PARTNERS: "en/partners/"
         - FAQ: "en/faq/"
+        - STATISTICS: "stat/"
         - OPEN DATA: "en/opendata/"
       CONTRIBUTE:
         - ACTIVATE YOUR COMMUNITY: "en/contribute/"

--- a/scripts/plotStatistiche.py
+++ b/scripts/plotStatistiche.py
@@ -1,0 +1,79 @@
+import pandas as pd
+from math import pi
+from bokeh.io import output_file, show
+from bokeh.plotting import figure
+from bokeh.models.tools import BoxZoomTool, ResetTool
+from bokeh.models import DatetimeTickFormatter
+from bokeh.layouts import column
+import os
+import json
+from bokeh.embed import json_item
+
+
+PATH_TO_DATA = '../_data/machgen/issues.csv'
+PATH_TO_PLOT = '../_data/plot'
+
+
+def load_issue_data():
+    issues = pd.read_csv(PATH_TO_DATA,
+            parse_dates=['updated_at', 'created_at'],
+            index_col='id')
+
+    s = issues['labels'].apply(eval).explode()
+    p = pd.crosstab(s.index, s)
+    labels = p.columns.to_list()
+    for l in ['tweet', 'telegram-channel', 'Valid/Accettato']:
+        if l in labels:
+            labels.remove(l)
+
+    issues = issues.join(p)
+    return issues, labels
+
+def issue_category_count_plot(issues: pd.DataFrame, labels: list):
+    labels_count = [issues[l].sum() for l in labels]
+    sorted_labels = sorted(labels, key=lambda x: labels_count[labels.index(x)])
+
+    p = figure(y_range=sorted_labels,
+                title='Number of issues per category',
+                x_axis_label="Number of issues",
+                y_axis_label="Categories",
+                tools='save,hover',
+                tooltips="@labels: @count"
+    )
+    p.toolbar.logo = None
+    p.ygrid.grid_line_color = None
+    p.x_range.start = 0
+    source = dict(labels=labels, count=labels_count)
+    p.hbar(y='labels', right='count', height=0.9, source=source)
+    return p
+
+def cumulative_sum_issue_over_time(issues):
+    data = issues.groupby(issues['created_at'].dt.date)['url'].count().cumsum()
+    data.index = pd.to_datetime(data.index)
+    data = data.resample('D').ffill()
+    p = figure(width=800, height=250,
+                title="Issues cumulative sum",
+                x_axis_label='Date',
+                y_axis_label='Cumulative sum',
+                x_axis_type="datetime",
+                tools='save')
+    p.toolbar.logo = None
+    p.line(data.index, data.values, line_width=2)
+    p.xaxis.major_label_orientation = pi/4
+    p.xaxis[0].formatter = DatetimeTickFormatter(days="%d/%m/%y")
+    p.xaxis[0].ticker.desired_num_ticks = 10
+    return p
+
+
+
+if __name__ == '__main__':
+    issues, labels = load_issue_data()
+    plot1 = issue_category_count_plot(issues, labels)
+    plot2 = cumulative_sum_issue_over_time(issues)
+    # show(plot)
+    grid = column(plot1, plot2)
+    show(grid)
+
+    with open(os.path.join(PATH_TO_PLOT, 'plot.json'), 'w') as f:
+        json.dump(json_item(grid, "statplot"), f)
+

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,14 @@
+bokeh==2.4.2
+Jinja2==3.1.1
+MarkupSafe==2.1.1
+numpy==1.22.3
+packaging==21.3
+pandas==1.4.2
+Pillow==9.1.0
+pyparsing==3.0.7
+python-dateutil==2.8.2
+pytz==2022.1
+PyYAML==6.0
+six==1.16.0
+tornado==6.1
+typing_extensions==4.1.1

--- a/stat.md
+++ b/stat.md
@@ -1,0 +1,18 @@
+---
+lang: it
+layout: page
+title: Statistiche
+subtitle: Statistiche sulle segnalazioni
+permalink: /stat/
+---
+
+<script src="//cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
+
+<div id="statplot"></div>
+
+
+<script>
+    Bokeh.set_log_level("debug");
+    Bokeh.embed.embed_item({{ site.data.plot.plot | jsonify }})
+</script>
+


### PR DESCRIPTION
- aggiunta pagina con grafici relativi alle statistiche delle segnalazioni

Lo script per generare le statistiche:
- carica le segnalazioni dal file `issues.csv`
- genera dei file json che descrivono i grafici, usando la libreria python [Bokeh](https://bokeh.pydata.org/)
- la pagina `stat.md` carica i file json e mostra i grafici (usando libreria javascript di Bokeh)
- i grafici sono interattivi

Idealmente lo script dovrebbe essere una Github action nel repository https://github.com/emergenzeHack/ukrainehelp.emergenzehack.info_segnalazioni/. In questo modo, ogni volta che viene aggiunta una segnalazione, i grafici si aggiornano (analogamente a quanto avviene con i file csv, json e geojson delle segnalazioni). Le variabile `PATH_TO_DATA` e `PATH_TO_PLOT` nello script andrebbero aggiornate in base a dove si decide di eseguire lo script.

Lo script è testato con python 3.9. 

<img width="548" alt="Screenshot 2022-04-06 at 20 16 01" src="https://user-images.githubusercontent.com/6319051/162043468-b59b76fa-2883-4740-8900-c803b1139758.png">

